### PR TITLE
release v2.0.3

### DIFF
--- a/includes/Installer.php
+++ b/includes/Installer.php
@@ -617,6 +617,13 @@ KEY expense_id (expense_id)
 				}
 			}
 		}
+		// remove legacy roles that starts with 'ea_'.
+		$roles = wp_roles()->roles;
+		foreach ( $roles as $role => $details ) {
+			if ( strpos( $role, 'ea_' ) === 0 ) {
+				remove_role( $role );
+			}
+		}
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-ever-accounting",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "The Best WordPress Accounting Plugin ever made!",
   "keywords": [],
   "homepage": "https://www.wpeveraccounting.com",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: accounting, invoice, CRM, business, finance
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -289,6 +289,9 @@ Yes, you can contribute to WP Ever Accounting. We welcome contributions from the
 38. Settings: Add/Edit Category.
 
 == Changelog ==
+= 2.0.3 = (1 December 2024)
+* Fix: Remove legacy roles those are not used anymore.
+
 = 2.0.2 = (30 November 2024)
 * New: Add filter by date for payments, invoices, expenses, transfers, and bills.
 * New: Add button for adding new items in the payment, invoice, expense, transfer, and bill view/edit page.

--- a/wp-ever-accounting.php
+++ b/wp-ever-accounting.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Ever Accounting
  * Plugin URI:        https://wpeveraccounting.com/
  * Description:       Manage your business finances right from your WordPress dashboard.
- * Version:           2.0.2
+ * Version:           2.0.3
  * Requires at least: 4.7.0
  * Tested up to:      6.7
  * Requires PHP:      7.4


### PR DESCRIPTION
This pull request includes several updates to the `wp-ever-accounting` plugin, focusing on version updates and the removal of legacy roles. The most important changes include updating the version number across multiple files and removing roles that start with 'ea_'.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.0.2` to `2.0.3`.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the stable tag from `2.0.2` to `2.0.3`.
* [`wp-ever-accounting.php`](diffhunk://#diff-38ce006ec81723692ad4df55b6d38e2439f97747adf8df99d216a7dcbc571fffL6-R6): Updated the plugin version from `2.0.2` to `2.0.3`.

Role removal:

* [`includes/Installer.php`](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916R620-R626): Added code to remove legacy roles that start with 'ea_'.

Changelog update:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R292-R294): Added a changelog entry for version `2.0.3`, noting the removal of legacy roles.