### PR TITLE
Extend items capabilities

### DIFF
--- a/includes/API/Items.php
+++ b/includes/API/Items.php
@@ -93,7 +93,7 @@ class Items extends Controller {
 	 * @return true|\WP_Error True, if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
-		if ( ! current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
+		if ( ! current_user_can( 'eac_read_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
 			return new \WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to view items.', 'wp-ever-accounting' ),
@@ -113,7 +113,7 @@ class Items extends Controller {
 	 * @return true|\WP_Error True, if the request has read access, WP_Error object otherwise.
 	 */
 	public function create_item_permissions_check( $request ) {
-		if ( ! current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
+		if ( ! current_user_can( 'eac_edit_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
 			return new \WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to create items.', 'wp-ever-accounting' ),
@@ -135,7 +135,7 @@ class Items extends Controller {
 	public function get_item_permissions_check( $request ) {
 		$item = EAC()->items->get( $request['id'] );
 
-		if ( empty( $item ) || ! current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
+		if ( empty( $item ) || ! current_user_can( 'eac_read_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
 			return new \WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to view this item.', 'wp-ever-accounting' ),
@@ -157,7 +157,7 @@ class Items extends Controller {
 	public function update_item_permissions_check( $request ) {
 		$item = EAC()->items->get( $request['id'] );
 
-		if ( empty( $item ) || ! current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
+		if ( empty( $item ) || ! current_user_can( 'eac_edit_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
 			return new \WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to update this item.', 'wp-ever-accounting' ),
@@ -179,7 +179,7 @@ class Items extends Controller {
 	public function delete_item_permissions_check( $request ) {
 		$item = EAC()->items->get( $request['id'] );
 
-		if ( empty( $item ) || ! current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
+		if ( empty( $item ) || ! current_user_can( 'eac_delete_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability
 			return new \WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to delete this item.', 'wp-ever-accounting' ),

--- a/includes/Admin/Items.php
+++ b/includes/Admin/Items.php
@@ -34,7 +34,7 @@ class Items {
 	 * @return array
 	 */
 	public static function register_tabs( $tabs ) {
-		if ( current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability.
+		if ( current_user_can( 'eac_read_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability.
 			$tabs['items'] = __( 'Items', 'wp-ever-accounting' );
 		}
 
@@ -49,7 +49,7 @@ class Items {
 	 */
 	public static function handle_edit() {
 		check_admin_referer( 'eac_edit_item' );
-		if ( ! current_user_can( 'eac_manage_item' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability.
+		if ( ! current_user_can( 'eac_edit_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom capability.
 			wp_die( esc_html__( 'You do not have permission to edit items.', 'wp-ever-accounting' ) );
 		}
 

--- a/includes/Admin/ListTables/Items.php
+++ b/includes/Admin/ListTables/Items.php
@@ -357,6 +357,14 @@ class Items extends ListTable {
 			),
 		);
 
+		if ( ! current_user_can( 'eac_delete_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Reason: This is a custom capability.
+			unset( $actions['delete'] );
+		}
+
+		if ( ! current_user_can( 'eac_edit_items' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Reason: This is a custom capability.
+			unset( $actions['edit'] );
+		}
+
 		return $this->row_actions( $actions );
 	}
 }

--- a/includes/Admin/Menus.php
+++ b/includes/Admin/Menus.php
@@ -76,7 +76,7 @@ class Menus {
 		add_menu_page(
 			__( 'Accounting', 'wp-ever-accounting' ),
 			__( 'Accounting', 'wp-ever-accounting' ),
-			'manage_accounting',  // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Reason: This is a custom capability.
+			'read_accounting',  // phpcs:ignore WordPress.WP.Capabilities.Unknown -- Reason: This is a custom capability.
 			self::PARENT_SLUG,
 			null,
 			$icon,
@@ -89,7 +89,7 @@ class Menus {
 			array(
 				'menu_title' => __( 'Dashboard', 'wp-ever-accounting' ),
 				'page_title' => __( 'Dashboard', 'wp-ever-accounting' ),
-				'capability' => 'manage_accounting',
+				'capability' => 'read_accounting',
 				'menu_slug'  => self::PARENT_SLUG,
 				'callback'   => array( Dashboard::class, 'render_page' ),
 			)

--- a/includes/Admin/Utilities.php
+++ b/includes/Admin/Utilities.php
@@ -20,7 +20,7 @@ class Utilities {
 	public static function get_menus() {
 		$menus = array(
 			array(
-				'capability' => 'eac_manage_item',
+				'capability' => 'eac_read_items',
 				'menu_slug'  => 'eac-items',
 				'menu_title' => __( 'Items', 'wp-ever-accounting' ),
 				'page_title' => __( 'Items', 'wp-ever-accounting' ),

--- a/includes/Installer.php
+++ b/includes/Installer.php
@@ -95,14 +95,14 @@ class Installer {
 							'version'  => $version,
 						)
 					);
-					++$loop;
+					++ $loop;
 				}
 			}
-			++$loop;
+			++ $loop;
 		}
 
 		if ( version_compare( EAC()->get_db_version(), EAC()->get_version(), '<' ) &&
-			! EAC()->queue()->get_next( 'eac_update_db_version' ) ) {
+			 ! EAC()->queue()->get_next( 'eac_update_db_version' ) ) {
 			EAC()->queue()->schedule_single(
 				time() + $loop,
 				'eac_update_db_version',
@@ -542,6 +542,7 @@ KEY expense_id (expense_id)
 			'eac_accountant',
 			'Accountant',
 			array(
+				'read_accounting'     => true,
 				'manage_accounting'   => true,
 				'eac_manage_customer' => true,
 				'eac_manage_vendor'   => true,
@@ -551,7 +552,9 @@ KEY expense_id (expense_id)
 				'eac_manage_transfer' => true,
 				'eac_manage_category' => true,
 				'eac_manage_currency' => true,
-				'eac_manage_item'     => true,
+				'eac_read_items'      => true,
+				'eac_edit_items'      => true,
+				'eac_delete_items'    => true,
 				'eac_manage_invoice'  => true,
 				'eac_manage_bill'     => true,
 				'eac_manage_tax'      => true,
@@ -564,6 +567,7 @@ KEY expense_id (expense_id)
 			'eac_manager',
 			'Accounting Manager',
 			array(
+				'read_accounting'     => true,
 				'manage_accounting'   => true,
 				'eac_manage_report'   => true,
 				'eac_manage_options'  => true,
@@ -576,7 +580,9 @@ KEY expense_id (expense_id)
 				'eac_manage_transfer' => true,
 				'eac_manage_category' => true,
 				'eac_manage_currency' => true,
-				'eac_manage_item'     => true,
+				'eac_read_items'      => true,
+				'eac_edit_items'      => true,
+				'eac_delete_items'    => true,
 				'eac_manage_invoice'  => true,
 				'eac_manage_bill'     => true,
 				'eac_manage_tax'      => true,
@@ -590,6 +596,7 @@ KEY expense_id (expense_id)
 		global $wp_roles;
 
 		if ( is_object( $wp_roles ) ) {
+			$wp_roles->add_cap( 'administrator', 'read_accounting' );
 			$wp_roles->add_cap( 'administrator', 'manage_accounting' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_report' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_options' );
@@ -601,7 +608,9 @@ KEY expense_id (expense_id)
 			$wp_roles->add_cap( 'administrator', 'eac_manage_transfer' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_category' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_currency' );
-			$wp_roles->add_cap( 'administrator', 'eac_manage_item' );
+			$wp_roles->add_cap( 'administrator', 'eac_read_items' );
+			$wp_roles->add_cap( 'administrator', 'eac_edit_items' );
+			$wp_roles->add_cap( 'administrator', 'eac_delete_items' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_invoice' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_bill' );
 			$wp_roles->add_cap( 'administrator', 'eac_manage_tax' );


### PR DESCRIPTION
This pull request includes several changes to the capabilities required for different actions in the `wp-ever-accounting` plugin. The main goal is to replace the custom capability `eac_manage_item` with more specific capabilities for reading, editing, and deleting items.

### Changes to Capabilities:

* [`includes/API/Items.php`](diffhunk://#diff-f509f300453488f48cfac02eaf76bc1673b77270470d6758641ff04edcce2bfcL96-R96): Updated various permission checks to use `eac_read_items`, `eac_edit_items`, and `eac_delete_items` instead of `eac_manage_item`. [[1]](diffhunk://#diff-f509f300453488f48cfac02eaf76bc1673b77270470d6758641ff04edcce2bfcL96-R96) [[2]](diffhunk://#diff-f509f300453488f48cfac02eaf76bc1673b77270470d6758641ff04edcce2bfcL116-R116) [[3]](diffhunk://#diff-f509f300453488f48cfac02eaf76bc1673b77270470d6758641ff04edcce2bfcL138-R138) [[4]](diffhunk://#diff-f509f300453488f48cfac02eaf76bc1673b77270470d6758641ff04edcce2bfcL160-R160) [[5]](diffhunk://#diff-f509f300453488f48cfac02eaf76bc1673b77270470d6758641ff04edcce2bfcL182-R182)

* [`includes/Admin/Items.php`](diffhunk://#diff-d932e50348d1f61eb5e0d033d25a9a0c60043aa22b2f7333c0791b2953d31fbdL37-R37): Modified the capability checks in the `register_tabs` and `handle_edit` methods to use `eac_read_items` and `eac_edit_items` respectively. [[1]](diffhunk://#diff-d932e50348d1f61eb5e0d033d25a9a0c60043aa22b2f7333c0791b2953d31fbdL37-R37) [[2]](diffhunk://#diff-d932e50348d1f61eb5e0d033d25a9a0c60043aa22b2f7333c0791b2953d31fbdL52-R52)

* [`includes/Admin/ListTables/Items.php`](diffhunk://#diff-78b74ae6fd2da38c0006a38e491e8b335ed51b7b6ee2f7e590e4485cc3786dfdR360-R367): Added capability checks for `eac_delete_items` and `eac_edit_items` to conditionally display row actions.

* [`includes/Admin/Menus.php`](diffhunk://#diff-d3746570fec704f378709e53b47d362df0be5c190091439db57b8fb782a79599L79-R79): Changed the capability required for the accounting menu from `manage_accounting` to `read_accounting`. [[1]](diffhunk://#diff-d3746570fec704f378709e53b47d362df0be5c190091439db57b8fb782a79599L79-R79) [[2]](diffhunk://#diff-d3746570fec704f378709e53b47d362df0be5c190091439db57b8fb782a79599L92-R92)

* [`includes/Installer.php`](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916R545): Updated the `create_roles` method to add the new capabilities (`read_accounting`, `eac_read_items`, `eac_edit_items`, `eac_delete_items`) to the relevant roles. [[1]](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916R545) [[2]](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916L554-R557) [[3]](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916R570) [[4]](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916L579-R585) [[5]](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916R599) [[6]](diffhunk://#diff-66f6d576b9be1d8b409e6551a7285d024c83f822a9ae3c7058a4a608649d2916L604-R613)